### PR TITLE
feat: 기안문 삭제 작업 및 알림 전체 읽음 기능 추가

### DIFF
--- a/src/main/java/com/server/intranet/approval/controller/ApprovalController.java
+++ b/src/main/java/com/server/intranet/approval/controller/ApprovalController.java
@@ -25,6 +25,14 @@ public class ApprovalController {
 
     private final ApprovalServiceImpl approvalService;
 
+    /**
+     * methodName : selectApprovalMain
+     * author : YunJae Lee
+     * description :
+     *
+     * @return response entity
+     * @throws Exception the exception
+     */
     @GetMapping("")
     public ResponseEntity<Map<String,Object>> selectApprovalMain() throws Exception{
         System.out.println("전자 " + SecurityUtil.getCurrentUserId());
@@ -127,6 +135,7 @@ public class ApprovalController {
         ApprovalResponseDTO approval = approvalService.selectApprovalDetail(approvalId, type);
 
         Map<String,Object> employee = new HashMap<>();
+        employee.put("id",SecurityUtil.getCurrentUserId());
         employee.put("department",SecurityUtil.getCurrentUserDepartmentName());
         employee.put("name",SecurityUtil.getCurrentUserName());
         employee.put("level", SecurityUtil.getCurrentUserLevelName());
@@ -178,9 +187,15 @@ public class ApprovalController {
         Long data = approvalService.updateApprovalCancel(requestDTO);
 
         Map<String, Object> map = new HashMap<>();
-        map.put("data", data);
-        map.put("code", "SUCCESS");
-        map.put("msg", "저장이 완료되었습니다.");
+        if(data == 10L){
+            map.put("code", "FAIL");
+            map.put("msg", "이미 결재가 진행되었습니다.");
+        } else {
+            map.put("data",data);
+            map.put("code", "SUCCESS");
+            map.put("msg", "상신 취소가 완료되었습니다.");
+        }
+
 
         return ResponseEntity.ok().body(map);
     }
@@ -203,6 +218,26 @@ public class ApprovalController {
         map.put("data", data);
         map.put("code", "SUCCESS");
         map.put("msg", "저장이 완료되었습니다.");
+
+        return ResponseEntity.ok().body(map);
+    }
+
+    /**
+     * methodName : deleteApproval
+     * author : YunJae Lee
+     * description : 기안문 삭제
+     *
+     * @param id
+     * @return response entity
+     * @throws Exception the exception
+     */
+    @DeleteMapping("/draft/doc/{id}")
+    public ResponseEntity<Map<String,Object>> deleteApproval(@PathVariable("id") Long id) throws Exception{
+        approvalService.deleteApproval(id);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("code", "SUCCESS");
+        map.put("msg", "삭제가 완료되었습니다.");
 
         return ResponseEntity.ok().body(map);
     }

--- a/src/main/java/com/server/intranet/approval/controller/NotificationController.java
+++ b/src/main/java/com/server/intranet/approval/controller/NotificationController.java
@@ -63,4 +63,16 @@ public class NotificationController {
 
         return ResponseEntity.ok().body(map);
     }
+
+    //알림 모두 읽음
+    @PostMapping("/app/auth/notice/{id}")
+    public ResponseEntity<Map<String,Object>> readNotificationAll(@PathVariable Long id) {
+        notificationServiceImpl.readNotificationAll(id);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("code", "SUCCESS");
+        map.put("msg", "모두 읽음처리 되었습니다");
+
+        return ResponseEntity.ok().body(map);
+    }
 }

--- a/src/main/java/com/server/intranet/approval/dto/ApprovalResponseDTO.java
+++ b/src/main/java/com/server/intranet/approval/dto/ApprovalResponseDTO.java
@@ -37,5 +37,6 @@ public class ApprovalResponseDTO {
     private String category;
     private String approvalType;    //상세페이지 접속 때 기안자/결재자 구분
     private LocalDateTime creationDate;
+    private LocalDateTime modificationDate;
     private List<ParticipantResponseDTO> participantList;
 }

--- a/src/main/java/com/server/intranet/approval/entity/ApprovalElectronic.java
+++ b/src/main/java/com/server/intranet/approval/entity/ApprovalElectronic.java
@@ -71,7 +71,7 @@ public class ApprovalElectronic {
     private Integer docNo;
 
     @CreatedDate
-    @Column(name = "CREATION_DATE")
+    @Column(name = "CREATION_DATE", updatable = false)
     private LocalDateTime creationDate;
 
     @LastModifiedDate

--- a/src/main/java/com/server/intranet/approval/entity/ApprovalForm.java
+++ b/src/main/java/com/server/intranet/approval/entity/ApprovalForm.java
@@ -58,7 +58,7 @@ public class ApprovalForm {
     private String preApproval;
 
     @CreatedDate
-    @Column(name = "CREATION_DATE")
+    @Column(name = "CREATION_DATE", updatable = false)
     private LocalDateTime creationDate;
 
     @LastModifiedDate

--- a/src/main/java/com/server/intranet/approval/repository/ApprovalElectronicRepository.java
+++ b/src/main/java/com/server/intranet/approval/repository/ApprovalElectronicRepository.java
@@ -19,31 +19,39 @@ import java.util.List;
  * 2024-06-28        gladious       최초 생성
  */
 public interface ApprovalElectronicRepository extends JpaRepository<ApprovalElectronic, Long> {
+    //메인페이지 기안 문서함
+    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE a.employee_id  = :employeeId AND a.type = '기안' AND e.status != 'T' AND e.status != 'H' ORDER BY e.approval_id DESC LIMIT 5;" , nativeQuery = true)
+    List<ApprovalElectronic> findByDraft(@Param("employeeId") Long employeeId);
+
     //기안 문서함
-    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE a.employee_id  = :employeeId AND a.type = :type AND e.status != 'T';" , nativeQuery = true)
+    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE a.employee_id  = :employeeId AND a.type = :type AND e.status != 'T' AND e.status != 'H' ORDER BY e.approval_id DESC;" , nativeQuery = true)
     List<ApprovalElectronic> findByApprovalIdAndDraft(@Param("employeeId") Long employeeId, @Param("type") String type );
 
     //임시/결재 문서함
-    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE e.status = :status AND a.employee_id  = :employeeId AND a.type = :type;" , nativeQuery = true)
+    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE e.status = :status AND a.employee_id  = :employeeId AND a.type = :type ORDER BY e.approval_id DESC;" , nativeQuery = true)
     List<ApprovalElectronic> findByApprovalIdAndTA( @Param("status")String status, @Param("employeeId") Long employeeId, @Param("type") String type);
 
     //결재 대기함
-    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE e.status = a.sequence AND a.employee_id  = :employeeId AND a.type = :type;" , nativeQuery = true)
+    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE e.status = a.sequence AND a.employee_id  = :employeeId AND a.type = :type ORDER BY e.approval_id DESC;" , nativeQuery = true)
     List<ApprovalElectronic> findByApprovalIdAndTodo( @Param("employeeId") Long employeeId, @Param("type") String type);
 
     //결재 예정 대기함
-    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE e.status REGEXP '^[0-9]+$' AND a.sequence REGEXP '^[0-9]+$' AND e.status < a.sequence AND a.employee_id = :employeeId AND a.type = :type;" , nativeQuery = true)
+    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE e.status REGEXP '^[0-9]+$' AND a.sequence REGEXP '^[0-9]+$' AND e.status < a.sequence AND a.employee_id = :employeeId AND a.type = :type ORDER BY e.approval_id DESC;" , nativeQuery = true)
     List<ApprovalElectronic> findByApprovalIdAndSchedule( @Param("employeeId") Long employeeId, @Param("type") String type);
+    
+    //결재 진행 문서함(작업중)
+    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE e.status != 'C' AND a.employee_id = :employeeId AND a.type = :type AND approval_status = '승인' ORDER BY e.approval_id DESC;" , nativeQuery = true)
+    List<ApprovalElectronic> findByApprovalIdAndProcess( @Param("employeeId") Long employeeId, @Param("type") String type);
 
-    //메인 페이지 내가 처리해야할 결재 대기(오름차순)
+    //전자결재 메인 페이지 내가 처리해야할 결재 대기(오름차순)
     @Query(value = "SELECT DISTINCT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE e.status = a.sequence AND a.employee_id = :employeeId AND a.type = '결재' ORDER BY e.urgency DESC, e.approval_id LIMIT 5;" , nativeQuery = true)
     List<ApprovalElectronic> findByMainAndTodo(@Param("employeeId") Long employeeId);
 
-    //메인 페이지 내가 올린 기안문 중 진행중 상태(내림차순)
-    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE a.employee_id = :employeeId AND a.type = '기안' AND e.status NOT IN ('T', 'C', 'R') ORDER BY e.approval_id DESC LIMIT 5;" , nativeQuery = true)
+    //전자결재 메인 페이지 내가 올린 기안문 중 진행중 상태(내림차순)
+    @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE a.employee_id = :employeeId AND a.type = '기안' AND e.status NOT IN ('T', 'C', 'R', 'H') ORDER BY e.approval_id DESC LIMIT 5;" , nativeQuery = true)
     List<ApprovalElectronic> findByMainAndDraftProgress(@Param("employeeId") Long employeeI);
 
-    //메인 페이지 내가 올린 기안문 중 완료되 상태(내림차순)
+    //전자결재 메인 페이지 내가 올린 기안문 중 완료되 상태(내림차순)
     @Query(value = "SELECT e.* FROM electronic_approval e JOIN approval_participant a ON e.approval_id = a.approval_id WHERE a.employee_id = :employeeId AND a.type = '기안' AND e.status IN ('C') ORDER BY e.approval_id DESC LIMIT 5;" , nativeQuery = true)
     List<ApprovalElectronic> findByMainAndDraftComplete(@Param("employeeId") Long employeeI);
 

--- a/src/main/java/com/server/intranet/approval/repository/NotificationRepository.java
+++ b/src/main/java/com/server/intranet/approval/repository/NotificationRepository.java
@@ -1,10 +1,13 @@
 package com.server.intranet.approval.repository;
 
 import com.server.intranet.approval.entity.Notification;
+import com.server.intranet.resource.entity.EmployeeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findAllByEmployeeId_EmployeeId(Long id);
+
+    List<Notification> findByEmployeeId(EmployeeEntity employeeId);
 }

--- a/src/main/java/com/server/intranet/approval/service/ApprovalService.java
+++ b/src/main/java/com/server/intranet/approval/service/ApprovalService.java
@@ -17,4 +17,5 @@ public interface ApprovalService {
     public ApprovalResponseDTO updateApproval(ApprovalRequestDTO requestDTO) throws Exception;
     public Long updateApprovalCancel(ApprovalRequestDTO requestDTO) throws Exception;
     public Long updateApprovalRejection(ApprovalRequestDTO requestDTO) throws Exception;
+    public void deleteApproval(Long id) throws Exception;
 }

--- a/src/main/java/com/server/intranet/approval/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/server/intranet/approval/service/impl/NotificationServiceImpl.java
@@ -99,15 +99,22 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Transactional
     public void readNotification(Long id) {
-        Notification notification = notificationRepository.findById(id)
-                .orElseThrow();
+        Notification notification = notificationRepository.findById(id).orElseThrow();
         notification.read();
     }
 
     @Transactional
     public void viewNotification(Long id) {
-        Notification notification = notificationRepository.findById(id)
-                .orElseThrow();
+        Notification notification = notificationRepository.findById(id).orElseThrow();
         notification.view();
+    }
+
+    @Transactional
+    public void readNotificationAll(Long id) {
+        Notification notification = notificationRepository.findById(id).orElseThrow();
+        List<Notification> notificationList = notificationRepository.findByEmployeeId(notification.getEmployeeId());
+        for(Notification notice : notificationList){
+            notice.read();
+        }
     }
 }


### PR DESCRIPTION
- 상세조회 employeeId가 기안자랑 다르면 리턴
- 기안문 상신취소 결재가 진행된 후 요청시 메세지 첨부
- 알림 모두 읽음
- 기안문 삭제
- 날짜 결재시 결재한 날짜로 노출되는 오류 수정